### PR TITLE
Don't blank cursor in beamer window

### DIFF
--- a/src/BeamerWidget.cpp
+++ b/src/BeamerWidget.cpp
@@ -23,7 +23,6 @@ BeamerWidget::BeamerWidget(const QGLFormat &format, PDFThread *pdfthread, Animat
 	initblend=false;
         waitingforcache=false;
 	wasanimated=false;
-	setCursor(Qt::BlankCursor);
 }
 
 BeamerWidget::~BeamerWidget()


### PR DESCRIPTION
This fixes the flickering cursor issue #1 